### PR TITLE
fix: インクリメンタルサーチが機能しない問題を修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__playwright__browser_snapshot",
+      "mcp__playwright__browser_navigate"
+    ]
+  }
+}

--- a/content.js
+++ b/content.js
@@ -24,10 +24,10 @@ addStyle(
 const filterList = (event) => {
   try {
     let filter = event.target.value.toUpperCase();
-    let ul = document.querySelector('ul[aria-label="カテゴリーを選ぶ"]');
+    let ul = document.querySelector('ul[aria-label="ストックリストを選ぶ"]');
     if (!ul)
       throw new Error(
-        "カテゴリーリストが見つかりません（「カテゴリーを選ぶ」というaria-labelがついたulが見つかりません）"
+        "ストックリストが見つかりません（「ストックリストを選ぶ」というaria-labelがついたulが見つかりません）"
       );
 
     let li = ul.getElementsByTagName("li");


### PR DESCRIPTION
## Summary
- Qiitaサイト側のUIリニューアルにより、ストックポップアップ内リストのaria-labelが「カテゴリーを選ぶ」→「ストックリストを選ぶ」に変更されていたため、フィルタリングが機能しなくなっていた問題を修正
- Claude Code設定ファイルを追加

## 原因
`filterList()`内で`ul[aria-label="カテゴリーを選ぶ"]`を参照していたが、Qiita側で`ul[aria-label="ストックリストを選ぶ"]`に変更されていた

## 変更内容
- `content.js`: aria-labelセレクターとエラーメッセージを更新
- `.claude/settings.local.json`: Claude Code設定ファイルを追加

## Test plan
- [x] Playwrightで実際のQiitaサイト上でフィルタリング動作を検証済み（218件中「Ruby」で3件に正しく絞り込み確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)