### PR TITLE
fix: content.jsの多重inject防止ガードを追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,3 +1,9 @@
+// 多重inject防止
+if (window.__qiitaIncrementalSearchInjected) {
+  throw new Error("already injected");
+}
+window.__qiitaIncrementalSearchInjected = true;
+
 // スタイルを追加するための関数
 const addStyle = (styles) => {
   let css = document.createElement("style");


### PR DESCRIPTION
## 概要

SPAナビゲーション等で `content.js` が同じページに複数回injectedされた際に発生する `Uncaught SyntaxError: Identifier 'addStyle' has already been declared` エラーを修正。

## 原因

`background.js` の `chrome.tabs.onUpdated` がQiitaのSPAナビゲーションで複数回発火し、`content.js` が同一タブに重複inject されていた。

## 修正内容

`content.js` の先頭に `window.__qiitaIncrementalSearchInjected` フラグによる実行済みチェックを追加。2回目以降のinjectは早期終了する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)