### PR TITLE
fix: QiitaのDOM変更に対応しセレクタを更新 (v1.7)

### DIFF
--- a/content.js
+++ b/content.js
@@ -26,14 +26,21 @@ addStyle(
   ".chrome-extension-qiita-incremental-search input { width: 100%; font-size: 16px;}"
 );
 
+const STOCK_BTN_SELECTOR =
+  'button[aria-label="ストックする"][aria-expanded="true"], button[aria-label="ストックを編集する"][aria-expanded="true"]';
+
 // フィルタリング関数
 const filterList = (event) => {
   try {
     let filter = event.target.value.toUpperCase();
-    let ul = document.querySelector('ul[aria-label="ストックリストを選ぶ"]');
+    const stockBtn = document.querySelector(STOCK_BTN_SELECTOR);
+    if (!stockBtn) return;
+    const dialog = document.getElementById(stockBtn.getAttribute("aria-controls"));
+    if (!dialog) return;
+    let ul = dialog.querySelector('ul[aria-label="ストックリスト"]');
     if (!ul)
       throw new Error(
-        "ストックリストが見つかりません（「ストックリストを選ぶ」というaria-labelがついたulが見つかりません）"
+        "ストックリストが見つかりません（「ストックリスト」というaria-labelがついたulが見つかりません）"
       );
 
     let li = ul.getElementsByTagName("li");
@@ -48,28 +55,31 @@ const filterList = (event) => {
 };
 // 要素をチェックし、必要なら新しいdivを挿入する関数
 const checkElements = () => {
-  let elements = document.getElementsByClassName("style-1w73du3");
-  for (let i = 0; i < elements.length; i++) {
-    let element = elements[i];
-    if (
-      !element.nextSibling ||
-      element.nextSibling.className !==
-        "chrome-extension-qiita-incremental-search"
-    ) {
-      let newDiv = document.createElement("div");
-      newDiv.className = "chrome-extension-qiita-incremental-search";
-      let newText = document.createElement("span");
-      newText.className = "chrome-extension-qiita-incremental-search-text";
-      newText.textContent = "絞り込み：";
-      let input = document.createElement("input");
-      input.type = "text";
-      input.addEventListener("input", filterList);
-      newDiv.appendChild(newText);
-      newDiv.appendChild(input);
-      element.parentNode.insertBefore(newDiv, element.nextSibling);
-      input.focus();
-    }
-  }
+  const stockBtn = document.querySelector(STOCK_BTN_SELECTOR);
+  if (!stockBtn) return;
+
+  const dialogId = stockBtn.getAttribute("aria-controls");
+  const dialog = dialogId ? document.getElementById(dialogId) : null;
+  if (!dialog) return;
+
+  const list = dialog.querySelector('ul[aria-label="ストックリスト"]');
+  if (!list) return;
+
+  if (dialog.querySelector("#chrome-extension-qiita-incremental-search")) return;
+
+  let newDiv = document.createElement("div");
+  newDiv.id = "chrome-extension-qiita-incremental-search";
+  newDiv.className = "chrome-extension-qiita-incremental-search";
+  let newText = document.createElement("span");
+  newText.className = "chrome-extension-qiita-incremental-search-text";
+  newText.textContent = "絞り込み：";
+  let input = document.createElement("input");
+  input.type = "text";
+  input.addEventListener("input", filterList);
+  newDiv.appendChild(newText);
+  newDiv.appendChild(input);
+  list.parentNode.insertBefore(newDiv, list);
+  input.focus();
 };
 
 // 1秒ごとにcheckElementsを呼び出す

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qiita ストック インクリメンタルサーチ",
   "description": "Qiitaの記事ストック時に、カテゴリーの絞り込み検索ができるようになる拡張機能です。",
-  "version": "1.6",
+  "version": "1.7",
   "permissions": ["scripting"],
   "host_permissions": ["https://qiita.com/*"],
   "action": {

--- a/popup.js
+++ b/popup.js
@@ -9,17 +9,21 @@ chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
 });
 
 function checkElement() {
-  let elements = document.getElementsByClassName("style-1w73du3");
-  return elements.length > 0;
+  const stockBtn = document.querySelector(
+    'button[aria-label="ストックする"], button[aria-label="ストックを編集する"]'
+  );
+  if (!stockBtn) return false;
+  const dialogId = stockBtn.getAttribute("aria-controls");
+  return dialogId ? !!document.getElementById(dialogId) : false;
 }
 
 let handleResult = (result) => {
   let statusElement = document.getElementById("status");
   if (result && result[0].result) {
     statusElement.textContent =
-      "ストックのポップアップ（style-1w73du3）が見つかりました！フォームが表示されてない場合、カテゴリー一覧のポップアップ表示後、数秒待ってみてください🙇";
+      "ストックのポップアップが見つかりました！フォームが表示されてない場合、カテゴリー一覧のポップアップ表示後、数秒待ってみてください🙇";
   } else {
     statusElement.textContent =
-      "ストックのポップアップを表示してみてください（style-1w73du3が見つかりませんでした）";
+      "ストックのポップアップを表示してみてください（ストックするボタンが見つかりませんでした）";
   }
 };


### PR DESCRIPTION
## Summary

- Qiitaのリニューアルで変わったDOM構造・クラス名に対応
- `style-1w73du3` クラスへの依存を廃止し、`aria-label` + `aria-controls` ベースの安定したセレクタに変更
- `ul[aria-label="ストックリストを選ぶ"]` → `ul[aria-label="ストックリスト"]` に更新
- ストック済み記事の「ストックを編集する」ボタンにも対応
- manifest.json バージョンを 1.6 → 1.7 に更新

## 変更ファイル

- `content.js` - セレクタをaria-attribute基準に刷新
- `popup.js` - 同様にセレクタ更新・メッセージから廃止クラス名を削除
- `manifest.json` - バージョン 1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)